### PR TITLE
Add delay to periodic callback/service

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -300,7 +300,8 @@ running callback to complete on stop. You need to use ``PeriodicService``
 as a base class and override ``callback`` async coroutine method.
 
 Service class accepts required ``interval`` argument - periodic interval
-in seconds.
+in seconds and
+optional ``delay`` argument - periodic execution delay in seconds (0 by default).
 
 .. code-block:: python
 
@@ -313,7 +314,7 @@ in seconds.
             log.info('Running periodic callback')
             # ...
 
-    service = MyPeriodicService(interval=3600)  # once per hour
+    service = MyPeriodicService(interval=3600, delay=0)  # once per hour
 
     with entrypoint(service) as loop:
         loop.run_forever()
@@ -1295,7 +1296,7 @@ This detects ``address`` format and select socket family automatically.
 Periodic callback
 +++++++++++++++++
 
-Runs coroutine function periodically.
+Runs coroutine function periodically with an optional delay of the first execution.
 
 .. code-block:: python
 
@@ -1313,8 +1314,8 @@ Runs coroutine function periodically.
 
         periodic = PeriodicCallback(periodic_function)
 
-        # Call it each second
-        periodic.start(1)
+        # Wait 10 seconds and call it each second after that
+        periodic.start(1, delay=10)
 
         loop.run_forever()
 

--- a/aiomisc/periodic.py
+++ b/aiomisc/periodic.py
@@ -32,6 +32,8 @@ class PeriodicCallback:
             await self._cb()
         except suppress_exceptions:
             return
+        except asyncio.CancelledError:
+            raise
         except Exception:
             log.exception("Periodic task error:")
 
@@ -71,7 +73,7 @@ class PeriodicCallback:
 
             self._handle = self._loop.call_later(interval, periodic)
 
-        self._loop.call_soon_threadsafe(self._loop.call_later, delay, periodic)
+        self._loop.call_later(delay, self._loop.call_soon_threadsafe, periodic)
 
     def stop(self):
         self._closed = True

--- a/aiomisc/periodic.py
+++ b/aiomisc/periodic.py
@@ -36,7 +36,9 @@ class PeriodicCallback:
             log.exception("Periodic task error:")
 
     def start(self, interval: Union[int, float],
-              loop=None, *, shield: bool = False,
+              loop=None, *,
+              delay: Union[int, float] = 0,
+              shield: bool = False,
               suppress_exceptions: Tuple[Type[Exception]] = ()):
 
         if self._closed:
@@ -69,7 +71,7 @@ class PeriodicCallback:
 
             self._handle = self._loop.call_later(interval, periodic)
 
-        self._loop.call_soon_threadsafe(periodic)
+        self._loop.call_soon_threadsafe(self._loop.call_later, delay, periodic)
 
     def stop(self):
         self._closed = True

--- a/aiomisc/service/periodic.py
+++ b/aiomisc/service/periodic.py
@@ -11,13 +11,14 @@ class PeriodicService(Service):
     __required__ = ('interval',)
 
     interval = None  # type: float # in seconds
+    delay = 0  # type: float # in seconds
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.periodic = PeriodicCallback(self.callback)
 
     async def start(self):
-        self.periodic.start(self.interval, loop=self.loop)
+        self.periodic.start(self.interval, delay=self.delay, loop=self.loop)
         log.info('Periodic service %s started', self)
 
     async def stop(self, err):
@@ -30,7 +31,8 @@ class PeriodicService(Service):
         raise NotImplementedError
 
     def __str__(self):
-        return '{}(interval={})'.format(
+        return '{}(interval={},delay={})'.format(
             self.__class__.__name__,
             self.interval,
+            self.delay,
         )

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -49,29 +49,39 @@ async def test_shield(loop):
 
     async def task():
         nonlocal counter
+        await asyncio.sleep(0.1)
         counter += 1
-        await asyncio.sleep(2)
 
     periodic = aiomisc.PeriodicCallback(task)
-    periodic.start(0.1, loop, shield=True)
+    periodic.start(0.2, loop, shield=True)
 
-    await asyncio.sleep(0)
+    # Wait for periodic callback to start
+    await asyncio.sleep(0.01)
 
     with pytest.raises(asyncio.CancelledError):
         await periodic.stop()
 
+    # Wait for counter to increment
+    await asyncio.sleep(0.1)
+
+    # Shielded
     assert counter == 1
 
     # No shield
     counter = 0
     periodic = aiomisc.PeriodicCallback(task)
-    periodic.start(0.1, loop, shield=False)
+    periodic.start(0.2, loop, shield=False)
 
-    await asyncio.sleep(0)
+    # Wait for periodic callback to start
+    await asyncio.sleep(0.01)
 
     with pytest.raises(asyncio.CancelledError):
         await periodic.stop()
 
+    # Wait for counter to increment
+    await asyncio.sleep(0.1)
+
+    # Cancelled
     assert counter == 0
 
 

--- a/tests/test_periodic.py
+++ b/tests/test_periodic.py
@@ -73,3 +73,24 @@ async def test_shield(loop):
         await periodic.stop()
 
     assert counter == 0
+
+
+async def test_delay(loop):
+    counter = 0
+
+    def task():
+        nonlocal counter
+        counter += 1
+
+    periodic = aiomisc.PeriodicCallback(task)
+    periodic.start(0.1, loop, delay=0.5)
+
+    await asyncio.sleep(0.25, loop=loop)
+
+    assert not counter
+
+    await asyncio.sleep(0.5, loop=loop)
+
+    periodic.stop()
+
+    assert 1 < counter < 4

--- a/tests/test_periodic_service.py
+++ b/tests/test_periodic_service.py
@@ -12,8 +12,8 @@ def test_str_representation():
     class FooPeriodicService(PeriodicService):
         ...
 
-    svc = FooPeriodicService(interval=42)
-    assert str(svc) == 'FooPeriodicService(interval=42)'
+    svc = FooPeriodicService(interval=42, delay=4815162342)
+    assert str(svc) == 'FooPeriodicService(interval=42,delay=4815162342)'
 
 
 def test_periodic():
@@ -38,6 +38,34 @@ def test_periodic():
 
         await asyncio.sleep(0.5)
         assert 4 <= counter <= 7
+
+    with aiomisc.entrypoint(svc) as loop:
+        loop.run_until_complete(assert_counter())
+
+
+def test_delay():
+    counter = 0
+
+    class CountPeriodicService(PeriodicService):
+        async def callback(self):
+            nonlocal counter
+            counter += 1
+            await asyncio.sleep(0)
+
+    svc = CountPeriodicService(interval=0.1, delay=0.5)
+
+    async def assert_counter():
+        nonlocal counter, svc
+
+        counter = 0
+        await asyncio.sleep(0.25)
+        assert not counter
+
+        await asyncio.sleep(0.5)
+
+        await svc.stop(None)
+
+        assert 1 < counter < 4
 
     with aiomisc.entrypoint(svc) as loop:
         loop.run_until_complete(assert_counter())


### PR DESCRIPTION
Sometimes it is desirable to delay execution of a periodic callback, e.g.
- spread periodic execution of multiple instances;
- delay first execution.