### PR TITLE
Add graceful service shutdown

### DIFF
--- a/aiomisc/service/graceful.py
+++ b/aiomisc/service/graceful.py
@@ -1,0 +1,58 @@
+import asyncio
+from asyncio import Task
+from typing import Coroutine
+
+from aiomisc import Service
+
+
+class GracefulMixin:
+
+    __tasks = {}
+
+    def create_graceful_task(self, coro: Coroutine, *, cancel: bool):
+        task = asyncio.create_task(coro)
+        task.add_done_callback(self.__pop_task)
+        self.__tasks[task] = cancel
+        return task
+
+    def __pop_task(self, task: Task):
+        self.__tasks.pop(task)
+
+    async def graceful_shutdown(self):
+        if self.__tasks:
+            items = list(self.__tasks.items())
+            to_cancel = [task for task, cancel in items if cancel]
+            to_wait = [task for task, cancel in items if not cancel]
+            await self.__wait_tasks(*to_cancel, cancel=True)
+            await self.__wait_tasks(*to_wait, cancel=False)
+            self.__tasks.clear()
+
+    @staticmethod
+    async def __wait_tasks(*tasks: Task, cancel: bool):
+        if not tasks:
+            return
+
+        to_stop = []
+
+        for task in tasks:
+            if task.done():
+                continue
+
+            if cancel:
+                task.cancel()
+
+            to_stop.append(task)
+
+        await asyncio.gather(
+            *to_stop,
+            return_exceptions=True,
+        )
+
+
+class GracefulService(Service, GracefulMixin):
+
+    async def start(self):
+        raise NotImplementedError
+
+    async def stop(self, exception: Exception = None):
+        await self.graceful_shutdown()

--- a/aiomisc/service/graceful.py
+++ b/aiomisc/service/graceful.py
@@ -29,7 +29,7 @@ class GracefulMixin:
             await waiter
 
             waiter = timeout(wait_timeout)(self.__wait_tasks)(
-                *to_wait, cancel=False
+                *to_wait, cancel=False,
             )
             with suppress(asyncio.TimeoutError):
                 await waiter
@@ -60,8 +60,10 @@ class GracefulMixin:
 
 class GracefulService(Service, GracefulMixin):
 
+    graceful_wait_timeout = None  # type: float # in seconds
+
     async def start(self):
         raise NotImplementedError
 
     async def stop(self, exception: Exception = None):
-        await self.graceful_shutdown()
+        await self.graceful_shutdown(wait_timeout=self.graceful_wait_timeout)

--- a/tests/test_graceful.py
+++ b/tests/test_graceful.py
@@ -1,0 +1,87 @@
+import asyncio
+from asyncio import CancelledError, Task
+
+import pytest
+
+from aiomisc.service.graceful import GracefulMixin, GracefulService
+
+
+async def test_graceful():
+    class Graceful(GracefulMixin):
+        pass
+
+    async def pho():
+        pass
+
+    graceful = Graceful()
+
+    task = graceful.create_graceful_task(pho(), cancel=False)
+    assert isinstance(task, Task)
+
+    await asyncio.sleep(0.1)
+
+    # Check that done and popped itself from the task store
+    assert task.done()
+    assert not graceful._GracefulMixin__tasks
+
+
+@pytest.mark.parametrize(
+    'cancel,expected', [
+        (False, None),
+        (True, CancelledError),
+    ]
+)
+async def test_graceful_shutdown(cancel, expected):
+    class Graceful(GracefulMixin):
+        pass
+
+    async def pho():
+        await asyncio.sleep(0.1)
+
+    graceful = Graceful()
+
+    task = graceful.create_graceful_task(pho(), cancel=cancel)
+    assert isinstance(task, Task)
+
+    await graceful.graceful_shutdown()
+    assert task.done()
+
+    if expected is None:
+        assert not task.exception()
+    else:
+        with pytest.raises(CancelledError):
+            task.exception()
+
+    assert not graceful._GracefulMixin__tasks
+
+
+async def test_graceful_service():
+    class TestService(GracefulService):
+
+        task_wait = None
+        task_cancel = None
+
+        async def start(self):
+            self.task_wait = self.create_graceful_task(
+                self.pho(), cancel=False
+            )
+            self.task_cancel = self.create_graceful_task(
+                self.pho(), cancel=True
+            )
+
+        async def pho(self):
+            await asyncio.sleep(0.1)
+
+    service = TestService()
+
+    await service.start()
+    await service.stop()
+
+    assert service.task_wait.done()
+    assert service.task_cancel.done()
+
+    assert not service.task_wait.exception()
+    with pytest.raises(CancelledError):
+        service.task_cancel.exception()
+
+    assert not service._GracefulMixin__tasks


### PR DESCRIPTION
Sometimes it is desirable to create tasks within a service that will either be awaited or cancelled upon service exit. Added
- `GracefulMixin` - creates and stores tasks for cancellation or waiting;
- `GracefulService` - performs graceful shutdown on stop.