### PR TITLE
Add condition to JSON log formatter to skip field for writing under old key (#89)

### DIFF
--- a/aiomisc/log/formatter/json.py
+++ b/aiomisc/log/formatter/json.py
@@ -70,6 +70,8 @@ class JSONLogFormatter(logging.Formatter):
         for key in record_dict:
             if key in data:
                 continue
+            elif key in self.FIELD_MAPPING:
+                continue
             elif key[0] == "_":
                 continue
 


### PR DESCRIPTION
Since we have mapping from old to key names for the fields, it makes no
sense to write the same values under the old key.