### PR TITLE
[fix] cron task tz info

### DIFF
--- a/aiomisc/cron.py
+++ b/aiomisc/cron.py
@@ -1,9 +1,8 @@
 import asyncio
 import logging
 import typing as t
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import partial
-import pytz
 
 from croniter import croniter
 
@@ -57,7 +56,7 @@ class CronCallback:
         if not self._loop or not self._croniter:
             raise asyncio.InvalidStateError
         loop_time = self._loop.time()
-        timestamp = datetime.now(pytz.utc).timestamp()
+        timestamp = datetime.now(timezone.utc).timestamp()
         interval = self._croniter.get_next(float) - timestamp
         if interval < 0:
             raise asyncio.InvalidStateError
@@ -67,7 +66,7 @@ class CronCallback:
         if not self._loop or not self._croniter:
             raise asyncio.InvalidStateError
         loop_time = self._loop.time()
-        timestamp = datetime.now(pytz.utc).timestamp()
+        timestamp = datetime.now(timezone.utc).timestamp()
         interval = self._croniter.get_current(float) - timestamp
         if interval < 0:
             raise asyncio.InvalidStateError
@@ -89,7 +88,7 @@ class CronCallback:
 
         # noinspection PyAttributeOutsideInit
         self._croniter = croniter(
-            spec, start_time=datetime.now(pytz.utc).timestamp(),
+            spec, start_time=datetime.now(timezone.utc).timestamp(),
         )
 
         self._closed = False

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -6,10 +6,13 @@ coverage==4.5.1
 coveralls
 croniter~=0.3.34
 fastapi
+freezegun<1.1
 mypy~=0.782
 pylava
 pytest
 pytest-cov~=2.5.1
+pytest-freezegun~=0.4.2
+pytz
 sphinx
 sphinx-autobuild
 sphinx-intl

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -12,7 +12,6 @@ pylava
 pytest
 pytest-cov~=2.5.1
 pytest-freezegun~=0.4.2
-pytz
 sphinx
 sphinx-autobuild
 sphinx-intl

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'develop': load_requirements('requirements.dev.txt'),
         'raven': ['raven-aiohttp'],
         'uvloop': ['uvloop>=0.14,<1'],
-        'cron': ['croniter~=0.3.34', 'pytz'],
+        'cron': ['croniter~=0.3.34'],
         ':python_version < "3.7"': 'async-generator',
     },
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         'develop': load_requirements('requirements.dev.txt'),
         'raven': ['raven-aiohttp'],
         'uvloop': ['uvloop>=0.14,<1'],
-        'cron': ['croniter~=0.3.34'],
+        'cron': ['croniter~=0.3.34', 'pytz'],
         ':python_version < "3.7"': 'async-generator',
     },
     entry_points={

--- a/tests/test_cron.py
+++ b/tests/test_cron.py
@@ -131,6 +131,6 @@ async def test_restart(loop):
 async def test_tz_next(loop, now):
     cron = CronCallback(lambda: True)
     with freeze_time(now):
-        handle = cron.start("*/10 * * * *", loop)
+        cron.start("*/10 * * * *", loop)
         expected = timedelta(minutes=10).total_seconds()
-        assert 0 <= handle.when() - loop.time() <= expected
+        assert 0 <= cron.get_current() - loop.time() <= expected


### PR DESCRIPTION
sry, missed that `datetime.utcnow` return without `tz_info` that leads to crashed time in calling `timestamp`