### PR TITLE
Fix session-scope agen fixture

### DIFF
--- a/aiomisc_pytest/pytest_plugin.py
+++ b/aiomisc_pytest/pytest_plugin.py
@@ -450,6 +450,9 @@ def pytest_fixture_setup(fixturedef):  # type: ignore
         if "loop" not in request.fixturenames:
             raise Exception("`loop` fixture required")
 
+        request._get_active_fixturedef("loop").addfinalizer(
+            partial(fixturedef.finish, request=request)
+        )
         event_loop = request.getfixturevalue("loop")
 
         if not is_async_gen:

--- a/tests/pytest_plugin/test_agen_fixture.py
+++ b/tests/pytest_plugin/test_agen_fixture.py
@@ -1,0 +1,21 @@
+import pytest
+
+from aiomisc import entrypoint
+
+
+class TestSessionScopeAsyncGenFixture:
+
+    @pytest.fixture(scope='session')
+    def loop(self):
+        with entrypoint() as loop:
+            yield loop
+
+    @pytest.fixture(scope='session')
+    async def fixture(self):
+        yield
+
+    async def test_using_fixture(self, fixture):
+        pass
+
+    async def test_not_using_fixture(self):
+        pass


### PR DESCRIPTION
As a potential solution to #127 we can add agen fixture's finalizer as a finilazer to the `loop` fixture. This way, `entrypoint` won't shutdown with [closing](https://github.com/aiokitchen/aiomisc/blob/master/aiomisc/entrypoint.py#L205 ) the loop before the fixture is finalized itself.

The main problem is usage of the private method `FixtureRequest._get_active_fixturedef`.