### PR TITLE
Require `typing-extensions` on Python < 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ croniter = { version = "^1.3.8", optional = true }
 logging-journald = [{ version = '*', platform = 'linux' }]
 raven = { version = "*", optional = true }
 rich = { version = "*", optional = true }
-typing_extensions = [{ version = '*', python = "< 3.8" }]
+typing_extensions = [{ version = '*', python = "< 3.10" }]
 uvloop = { version = ">=0.14, <1", optional = true }
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
... instead of Python < 3.8 earlier.
Because of https://github.com/aiokitchen/aiomisc/blob/397905d8ddfe3adcd1033a81f0609c4172062fb8/aiomisc/compat.py#L26-L29.