### PR TITLE
fix: Return coroutines instead of awaitables from functions.

### DIFF
--- a/aiomisc/aggregate.py
+++ b/aiomisc/aggregate.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 from inspect import Parameter
 from typing import (
     Any,
-    Awaitable,
     Callable,
+    Coroutine,
     Generic,
     Iterable,
     List,
@@ -246,7 +246,7 @@ class Aggregator(AggregatorAsync[V, R], Generic[V, R]):
 
 def aggregate(
     leeway_ms: float, max_count: Optional[int] = None
-) -> Callable[[AggregateFunc[V, R]], Callable[[V], Awaitable[R]]]:
+) -> Callable[[AggregateFunc[V, R]], Callable[[V], Coroutine[Any, Any, R]]]:
     """
     Parametric decorator that aggregates multiple
     (but no more than ``max_count`` defaulting to ``None``) single-argument
@@ -275,7 +275,9 @@ def aggregate(
 
     :return:
     """
-    def decorator(func: AggregateFunc[V, R]) -> Callable[[V], Awaitable[R]]:
+    def decorator(
+        func: AggregateFunc[V, R]
+    ) -> Callable[[V], Coroutine[Any, Any, R]]:
         aggregator = Aggregator(
             func, max_count=max_count, leeway_ms=leeway_ms,
         )
@@ -285,7 +287,10 @@ def aggregate(
 
 def aggregate_async(
     leeway_ms: float, max_count: Optional[int] = None,
-) -> Callable[[AggregateAsyncFunc[V, R]], Callable[[V], Awaitable[R]]]:
+) -> Callable[
+    [AggregateAsyncFunc[V, R]],
+    Callable[[V], Coroutine[Any, Any, R]]
+]:
     """
     Same as ``aggregate``, but with ``func`` arguments of type ``Arg``
     containing ``value`` and ``future`` attributes instead. In this setting
@@ -298,7 +303,7 @@ def aggregate_async(
     """
     def decorator(
         func: AggregateAsyncFunc[V, R]
-    ) -> Callable[[V], Awaitable[R]]:
+    ) -> Callable[[V], Coroutine[Any, Any, R]]:
         aggregator = AggregatorAsync(
             func, max_count=max_count, leeway_ms=leeway_ms,
         )

--- a/aiomisc/backoff.py
+++ b/aiomisc/backoff.py
@@ -2,7 +2,7 @@ import asyncio
 import sys
 from functools import wraps
 from typing import (
-    Any, Awaitable, Callable, Optional, Tuple, Type, TypeVar, Union,
+    Any, Callable, Coroutine, Optional, Tuple, Type, TypeVar, Union,
 )
 
 from .counters import Statistic
@@ -42,7 +42,10 @@ def asyncbackoff(
     giveup: Optional[Callable[[Exception], bool]] = None,
     statistic_name: Optional[str] = None,
     statistic_class: Type[BackoffStatistic] = BackoffStatistic,
-) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
+) -> Callable[
+    [Callable[P, Coroutine[Any, Any, T]]],
+    Callable[P, Coroutine[Any, Any, T]],
+]:
     """
     Patametric decorator that ensures that ``attempt_timeout`` and
     ``deadline`` time limits are met by decorated function.
@@ -85,7 +88,9 @@ def asyncbackoff(
     exceptions = tuple(exceptions) or ()
     exceptions += asyncio.TimeoutError,
 
-    def decorator(func: Callable[P, Awaitable[T]]) -> Callable[P, Awaitable[T]]:
+    def decorator(
+        func: Callable[P, Coroutine[Any, Any, T]]
+    ) -> Callable[P, Coroutine[Any, Any, T]]:
         if attempt_timeout is not None:
             func = timeout(attempt_timeout)(func)
 
@@ -145,7 +150,10 @@ def asyncretry(
     pause: Number = 0,
     giveup: Optional[Callable[[Exception], bool]] = None,
     statistic_name: Optional[str] = None,
-) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
+) -> Callable[
+    [Callable[P, Coroutine[Any, Any, T]]],
+    Callable[P, Coroutine[Any, Any, T]],
+]:
     """
     Shortcut of ``asyncbackoff(None, None, 0, Exception)``.
 

--- a/aiomisc/timeout.py
+++ b/aiomisc/timeout.py
@@ -1,7 +1,7 @@
 import asyncio
 import sys
 from functools import wraps
-from typing import Awaitable, Callable, TypeVar, Union
+from typing import Any, Callable, Coroutine, TypeVar, Union
 
 
 if sys.version_info >= (3, 10):
@@ -17,10 +17,13 @@ Number = Union[int, float]
 
 def timeout(
     value: Number
-) -> Callable[[Callable[P, Awaitable[T]]], Callable[P, Awaitable[T]]]:
+) -> Callable[
+    [Callable[P, Coroutine[Any, Any, T]]],
+    Callable[P, Coroutine[Any, Any, T]],
+]:
     def decorator(
-        func: Callable[P, Awaitable[T]],
-    ) -> Callable[P, Awaitable[T]]:
+        func: Callable[P, Coroutine[Any, Any, T]],
+    ) -> Callable[P, Coroutine[Any, Any, T]]:
         if not asyncio.iscoroutinefunction(func):
             raise TypeError("Function is not a coroutine function")
 


### PR DESCRIPTION
`Callable[..., Awaitable[T]]` is not a coroutine function, in fact it should be `Callable[..., Coroutine[Any, Any, T]]`.

If we have an interface like this:
```python
import abc

class AbstractClient(abc.ABC):
    @abc.abstractmethod
    async def fetch(self) -> bytes:
        ...
```

Then for such an implementation, mypy will return an error:
```python
import aiomisc

class Client(AbstractClient):
    @aiomisc.asyncretry(max_tries=3)
    async def fetch(self) -> bytes:
        ...
```

We can use workaround like this:
```python
import abc
from typing import Awaitable

class AbstractClient(abc.ABC):
    @abc.abstractmethod
    def fetch(self) -> Awaitable[bytes]:
        ...
```

But in this case `fetch` is not a coroutine function. We will have problems using `unittest.mock.MagicMock`:
```python
from unittest.mock import MagicMock

mocked_client = MagicMock(AbstractClient)
mocked_client.fetch.return_value = b'Hello, World!!!'

# will raise TypeError
await mocked_client.fetch()
```