### PR TITLE
DNS Zones Configuration Update

### DIFF
--- a/aiomisc/service/dns/zone.py
+++ b/aiomisc/service/dns/zone.py
@@ -1,28 +1,33 @@
 from collections import defaultdict
-from typing import DefaultDict, Sequence, Set, Tuple
+from typing import DefaultDict, Iterable, Sequence, Set, Tuple
 
 from .records import DNSRecord, RecordType
 
 
+RecordsType = DefaultDict[Tuple[str, RecordType], Set[DNSRecord]]
+
+
 class DNSZone:
-    records: DefaultDict[Tuple[str, RecordType], Set[DNSRecord]]
+    records: RecordsType
     name: str
 
     __slots__ = ("name", "records")
 
-    def __init__(self, name: str):
+    def __init__(self, name: str, *records: DNSRecord) -> None:
         if not name.endswith("."):
             name += "."
         self.name = name
         self.records = defaultdict(set)
 
+        for record in records:
+            self.add_record(record)
+
     def add_record(self, record: DNSRecord) -> None:
-        if not self._is_valid_record(record):
+        if not self.check_record(record):
             raise ValueError(
                 f"Record {record.name} does not belong to zone {self.name}",
             )
-        key = (record.name, record.type)
-        self.records[key].add(record)
+        self.records[(record.name, record.type)].add(record)
 
     def remove_record(self, record: DNSRecord) -> None:
         key = (record.name, record.type)
@@ -37,8 +42,26 @@ class DNSZone:
     ) -> Sequence[DNSRecord]:
         if not name.endswith("."):
             name += "."
-        key = (name, record_type)
-        return tuple(self.records.get(key, ()))
+        return tuple(self.records.get((name, record_type), ()))
 
-    def _is_valid_record(self, record: DNSRecord) -> bool:
+    def check_record(self, record: DNSRecord) -> bool:
         return record.name.endswith(self.name)
+
+    def replace(self, records: Iterable[DNSRecord]) -> None:
+        """
+        Atomically replace all records in specified zone with new ones.
+        This method is safe because it replaces all records at once.
+
+        If any of the records does not belong to the zone, ValueError
+        will be raised and no records will be replaced.
+        """
+        new_records: RecordsType = defaultdict(set)
+
+        for record in records:
+            if not self.check_record(record):
+                raise ValueError(
+                    f"Record {record.name} does not "
+                    f"belong to zone {self.name}",
+                )
+            new_records[(record.name, record.type)].add(record)
+        self.records = new_records


### PR DESCRIPTION
Adds atomic configuration reload capability for DNS zones and records.

Key changes:
- Introduces `replace()` method for both `DNSStore` and `DNSZone` classes to atomically update configurations
- Changes `DNSZone` constructor to accept initial records
- Renames `_is_valid_record` to `check_record` for better clarity
- Updates Store's replace method to use `Mapping` type for better zone name uniqueness

All changes covered by comprehensive test suite including edge cases like empty replacements and invalid records.

The main goal is to support safe configuration reloads from external sources (files, databases, etc.) while maintaining data consistency.