### PR TITLE
Allow to set custom periodic names

### DIFF
--- a/aiomisc/recurring.py
+++ b/aiomisc/recurring.py
@@ -48,14 +48,14 @@ class RecurringCallback:
 
     def __init__(
         self, coroutine_func: CallbackType,
-        *args: Any, **kwargs: Any,
+        *args: Any, name: Optional[str] = None, **kwargs: Any,
     ):
         self.func: Callable[..., Awaitable[Any]]
         self.args: Tuple[Any, ...]
         self.kwargs: Mapping[str, Any]
         self._statistic: RecurringCallbackStatistic
 
-        self.name: str = repr(coroutine_func)
+        self.name: str = name or repr(coroutine_func)
         self._statistic = RecurringCallbackStatistic(name=self.name)
         self.func = utils.awaitable(coroutine_func)
         self.args = args

--- a/aiomisc/service/periodic.py
+++ b/aiomisc/service/periodic.py
@@ -15,9 +15,9 @@ class PeriodicService(Service):
     interval: Union[int, float]
     delay: Union[int, float] = 0
 
-    def __init__(self, **kwargs: Any):
+    def __init__(self, *, name: Optional[str] = None, **kwargs: Any):
         super().__init__(**kwargs)
-        self.periodic = PeriodicCallback(self.callback)
+        self.periodic = PeriodicCallback(self.callback, name=name)
 
     async def start(self) -> None:
         assert self.interval, f"Interval illegal interval {self.interval!r}"


### PR DESCRIPTION
Add name parameter to RecurringCallback and PeriodicService

Changes:
- Added optional `name` parameter to RecurringCallback.__init__
- Falls back to function repr if name not provided
- Added name parameter to PeriodicService.__init__
- Passes name through to underlying PeriodicCallback

Impact:
- Allows better identification of callbacks in logs/metrics
- Maintains backward compatibility
