### PR TITLE
Fix typos in comments and docstrings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -273,7 +273,7 @@ Such as: ``AIOHTTPService``, ``ASGIService``, ``TCPServer``,
 
 Unfortunately in this section it is not possible to pay more attention to this,
 please pay attention to the Tutorial_ section section, there are more
-examples and explanations, and of cource you always can find out an answer on
+examples and explanations, and of course you always can find out an answer on
 the `/api/index` or in the source code. The authors have tried to make
 the source code as clear and simple as possible, so feel free to explore it.
 

--- a/docs/source/io.rst
+++ b/docs/source/io.rst
@@ -55,7 +55,7 @@ In general, for light loads, I would advise you to adhere to the following rules
   in summary.
 
   Just try pack all blocking staff in separate functions and
-  call it in a thread pool, see the example bellow:
+  call it in a thread pool, see the example below:
 
   .. code-block:: python
      :name: test_io_file_threaded

--- a/docs/source/locale/ru/LC_MESSAGES/io.po
+++ b/docs/source/locale/ru/LC_MESSAGES/io.po
@@ -142,7 +142,7 @@ msgstr ""
 #: ../../source/io.rst:57
 msgid ""
 "Just try pack all blocking staff in separate functions and call it in a "
-"thread pool, see the example bellow:"
+"thread pool, see the example below:"
 msgstr ""
 "Просто попробуйте завернуть все блокирующие вызовы в отдельные функции и "
 "вызывайте их используя пул потоков (см. пример ниже):"


### PR DESCRIPTION
Small typo fixes found with codespell:

- `README.rst:276`: `cource` -> `course`
- `docs/source/io.rst:58`: `bellow` -> `below`
- `docs/source/locale/ru/LC_MESSAGES/io.po:145`: `bellow` -> `below` (same string in English msgid)