### PR TITLE
Fix periodic self-stop and pytest 9 compatibility

### DIFF
--- a/aiomisc/entrypoint.py
+++ b/aiomisc/entrypoint.py
@@ -405,6 +405,8 @@ class Entrypoint:
         if self._loop_owner:
             await self._cancel_background_tasks()
             await self.loop.shutdown_asyncgens()
+            # Finish executor work before closing its loop.
+            await self.loop.shutdown_default_executor()
 
     def _on_interrupt_callback(self, _: Any) -> None:
         loop = self.loop

--- a/aiomisc/periodic.py
+++ b/aiomisc/periodic.py
@@ -69,7 +69,10 @@ class PeriodicCallback(EventLoopMixin):
         elif not self._task.done():
             self._task.cancel()
         task, self._task = self._task, None
-        return asyncio.gather(task, return_exceptions=return_exceptions)
+        # Avoid cancelling the callback while it is stopping itself.
+        return asyncio.shield(
+            asyncio.gather(task, return_exceptions=return_exceptions)
+        )
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self._recurring_callback.name})"

--- a/aiomisc/pytest.py
+++ b/aiomisc/pytest.py
@@ -494,9 +494,8 @@ def pytest_fixture_setup(fixturedef, request):  # type: ignore
             except StopAsyncIteration:  # NOQA
                 pass
 
-        loop_fixturedef.addfinalizer(
-            partial(fixturedef.finish, request=request)
-        )
+        # Adding this finalizer to event_loop breaks pytest 9+.
+        # The fixture's own finalizer is sufficient.
 
         request.addfinalizer(finalizer)
         return event_loop.run_until_complete(gen.__anext__())
@@ -666,8 +665,25 @@ def event_loop(
         if not loop.is_closed():
             with suppress(Exception):
                 loop.run_until_complete(loop.shutdown_asyncgens())
+            # Finish executor work before closing its loop.
+            with suppress(Exception):
+                loop.run_until_complete(loop.shutdown_default_executor())
             with suppress(Exception):
                 loop.close()
+
+        if exceptions:
+            logging.error(
+                "Unhandled exceptions found:\n\n\t%s",
+                "\n\t".join(
+                    ("Message: {m}\n\tFuture: {f}\n\tException: {e}").format(
+                        m=e["message"],
+                        f=repr(e.get("future")),
+                        e=repr(e.get("exception")),
+                    )
+                    for e in exceptions
+                ),
+            )
+            pytest.fail("Unhandled exceptions found. See logs.")
 
         asyncio.set_event_loop(None)
 

--- a/aiomisc/thread_pool.py
+++ b/aiomisc/thread_pool.py
@@ -77,6 +77,9 @@ class WorkItem(WorkItemBase):
 
         if self.loop.is_closed():
             log.warning("Event loop is closed. Ignoring %r", self.func)
+            # Do not leave the future pending after its loop has closed.
+            if not self.future.done():
+                self.future.set_exception(asyncio.CancelledError())
             raise asyncio.CancelledError
 
         result, exception = None, None
@@ -100,6 +103,9 @@ class WorkItem(WorkItemBase):
                 "Event loop is closed. Forget execution result for %r",
                 self.func,
             )
+            # Do not leave the future pending after its loop has closed.
+            if not self.future.done():
+                self.future.set_exception(asyncio.CancelledError())
             raise asyncio.CancelledError
 
         self.loop.call_soon_threadsafe(

--- a/tests/test_entrypoint.py
+++ b/tests/test_entrypoint.py
@@ -563,16 +563,16 @@ class AIOHTTPTestApp(AIOHTTPService):
         return aiohttp.web.Application()
 
 
-def test_aiohttp_service(aiomisc_unused_port):
+def test_aiohttp_service(aiomisc_unused_port, localhost):
     async def http_client():
         session = aiohttp.ClientSession()
-        url = f"http://localhost:{aiomisc_unused_port}"
+        url = f"http://{localhost}:{aiomisc_unused_port}"
 
         async with session:
             async with session.get(url) as response:
                 return response.status
 
-    service = AIOHTTPTestApp(address="127.0.0.1", port=aiomisc_unused_port)
+    service = AIOHTTPTestApp(address=localhost, port=aiomisc_unused_port)
 
     with aiomisc.entrypoint(service) as loop:
         response = loop.run_until_complete(
@@ -630,16 +630,16 @@ def test_aiohttp_service_without_port_or_sock(aiomisc_unused_port):
         ASGIHTTPTestApp()
 
 
-def test_asgi_service(aiomisc_unused_port):
+def test_asgi_service(aiomisc_unused_port, localhost):
     async def http_client():
         session = aiohttp.ClientSession()
-        url = f"http://localhost:{aiomisc_unused_port}"
+        url = f"http://{localhost}:{aiomisc_unused_port}"
 
         async with session:
             async with session.get(url) as response:
                 return response.status, await response.json()
 
-    service = ASGIHTTPTestApp(address="127.0.0.1", port=aiomisc_unused_port)
+    service = ASGIHTTPTestApp(address=localhost, port=aiomisc_unused_port)
 
     with aiomisc.entrypoint(service) as loop:
         response, body = loop.run_until_complete(
@@ -682,16 +682,16 @@ class UvicornTestService(UvicornService):
         return app
 
 
-def test_uvicorn_service(aiomisc_unused_port):
+def test_uvicorn_service(aiomisc_unused_port, localhost):
     async def http_client():
         session = aiohttp.ClientSession()
-        url = f"http://localhost:{aiomisc_unused_port}"
+        url = f"http://{localhost}:{aiomisc_unused_port}"
 
         async with session:
             async with session.get(url) as response:
                 return response.status, await response.json()
 
-    service = UvicornTestService(host="127.0.0.1", port=aiomisc_unused_port)
+    service = UvicornTestService(host=localhost, port=aiomisc_unused_port)
 
     with aiomisc.entrypoint(service) as loop:
         response, body = loop.run_until_complete(

--- a/tests/test_periodic_service.py
+++ b/tests/test_periodic_service.py
@@ -79,3 +79,22 @@ def test_delay(event_loop):
 
     with aiomisc.entrypoint(svc, loop=event_loop) as loop:
         loop.run_until_complete(asyncio.wait_for(assert_counter(), timeout=10))
+
+
+def test_stop_from_callback(event_loop):
+    # Regression test for https://github.com/aiokitchen/aiomisc/issues/250
+    class SelfStopping(PeriodicService):
+        calls = 0
+
+        async def callback(self) -> None:
+            self.calls += 1
+            if self.calls == 2:
+                await self.stop()
+
+    svc = SelfStopping(interval=0.05)
+
+    with aiomisc.entrypoint(svc, loop=event_loop) as loop:
+        loop.call_later(1.0, loop.stop)
+        loop.run_forever()
+
+    assert svc.calls == 2, "no callbacks must run after the service stopped"

--- a/tests/test_thread_pool.py
+++ b/tests/test_thread_pool.py
@@ -83,7 +83,7 @@ async def test_from_thread_channel_wait_before(event_loop, threaded_decorator):
             for i in range(10):
                 channel.put(i)
 
-    event_loop.call_later(0.1, in_thread)
+    producer = asyncio.ensure_future(in_thread())
 
     result = []
     with pytest.raises(ChannelClosed):
@@ -91,6 +91,7 @@ async def test_from_thread_channel_wait_before(event_loop, threaded_decorator):
             result.append(await asyncio.wait_for(channel.get(), timeout=5))
 
     assert result == list(range(10))
+    await asyncio.gather(producer, return_exceptions=True)
 
 
 async def test_from_thread_channel_close(event_loop):
@@ -187,6 +188,8 @@ async def test_future_when_pool_shutting_down(executor):
         for task in done:
             with pytest.raises(RuntimeError):
                 task.result()
+
+    await asyncio.gather(*futures, return_exceptions=True)
 
 
 async def test_failed_future_already_done(executor):


### PR DESCRIPTION
## Summary

- prevent recursive cancellation when a periodic callback stops itself
- complete thread-pool futures when their event loop is already closed
- wait for default executor tasks before closing an owned event loop
- avoid registering async fixture finalizers on `event_loop` for pytest 9+
- make related network and thread-pool tests deterministic

Fixes #250.